### PR TITLE
Implement voice control panel for Lucidus

### DIFF
--- a/lucidus-terminal-pro/README.md
+++ b/lucidus-terminal-pro/README.md
@@ -1,0 +1,3 @@
+# Lucidus Terminal Pro
+
+This plugin powers the Lucidus AI command center. The voice settings page allows admins to test and configure OpenAI text-to-speech voices.

--- a/lucidus-terminal-pro/admin/voice-settings.php
+++ b/lucidus-terminal-pro/admin/voice-settings.php
@@ -1,0 +1,77 @@
+<?php
+if ( ! current_user_can( 'manage_options' ) ) {
+    return;
+}
+
+if ( isset( $_POST['lucidus_voice_settings_nonce'] ) && wp_verify_nonce( $_POST['lucidus_voice_settings_nonce'], 'lucidus_voice_settings_save' ) ) {
+    if ( isset( $_POST['lucidus_voice_model'] ) ) {
+        update_option( 'lucidus_voice_model', sanitize_text_field( $_POST['lucidus_voice_model'] ) );
+    }
+    if ( isset( $_POST['lucidus_voice_speed'] ) ) {
+        update_option( 'lucidus_voice_speed', floatval( $_POST['lucidus_voice_speed'] ) );
+    }
+    if ( isset( $_POST['lucidus_voice_pitch'] ) ) {
+        update_option( 'lucidus_voice_pitch', floatval( $_POST['lucidus_voice_pitch'] ) );
+    }
+    if ( isset( $_POST['lucidus_voice_prompt'] ) ) {
+        update_option( 'lucidus_voice_prompt', sanitize_text_field( $_POST['lucidus_voice_prompt'] ) );
+    }
+    echo '<div class="updated"><p>Settings saved.</p></div>';
+}
+
+$model  = get_option( 'lucidus_voice_model', 'nova' );
+$speed  = get_option( 'lucidus_voice_speed', 1.0 );
+$pitch  = get_option( 'lucidus_voice_pitch', 0 );
+$prompt = get_option( 'lucidus_voice_prompt', 'Lucidus is alive.' );
+?>
+<div class="wrap">
+<h1>Lucidus Voice Settings</h1>
+<form method="post">
+<?php wp_nonce_field( 'lucidus_voice_settings_save', 'lucidus_voice_settings_nonce' ); ?>
+<table class="form-table">
+<tr>
+<th scope="row"><label for="lucidus_voice_model">Voice Model</label></th>
+<td>
+<select name="lucidus_voice_model" id="lucidus_voice_model">
+<?php
+$models = array( 'nova', 'echo', 'onyx', 'shimmer', 'fable' );
+foreach ( $models as $m ) {
+    echo '<option value="' . esc_attr( $m ) . '"' . selected( $model, $m, false ) . '>' . esc_html( ucfirst( $m ) ) . '</option>';
+}
+?>
+</select>
+</td>
+</tr>
+<tr>
+<th scope="row"><label for="lucidus_voice_speed">Speed</label></th>
+<td>
+<input type="range" name="lucidus_voice_speed" id="lucidus_voice_speed" min="0.25" max="4.0" step="0.05" value="<?php echo esc_attr( $speed ); ?>" oninput="document.getElementById('lucidus_speed_value').innerText = this.value" />
+<span id="lucidus_speed_value"><?php echo esc_html( $speed ); ?></span>
+</td>
+</tr>
+<tr>
+<th scope="row"><label for="lucidus_voice_pitch">Pitch</label></th>
+<td>
+<input type="range" name="lucidus_voice_pitch" id="lucidus_voice_pitch" min="-20" max="20" step="1" value="<?php echo esc_attr( $pitch ); ?>" oninput="document.getElementById('lucidus_pitch_value').innerText = this.value" />
+<span id="lucidus_pitch_value"><?php echo esc_html( $pitch ); ?></span>
+</td>
+</tr>
+<tr>
+<th scope="row"><label for="lucidus_voice_prompt">Prompt</label></th>
+<td>
+<input type="text" class="regular-text" name="lucidus_voice_prompt" id="lucidus_voice_prompt" value="<?php echo esc_attr( $prompt ); ?>" placeholder="Test phrase" />
+</td>
+</tr>
+</table>
+<p class="submit">
+<input type="submit" class="button-primary" value="Save Settings" />
+<button type="button" class="button" onclick="playLucidusTest()">Test Voice</button>
+</p>
+</form>
+</div>
+<script type="text/javascript">
+function playLucidusTest() {
+    const audio = new Audio("<?php echo admin_url( 'admin-ajax.php?action=lucidus_test_voice' ); ?>");
+    audio.play();
+}
+</script>

--- a/lucidus-terminal-pro/includes/openai-client.php
+++ b/lucidus-terminal-pro/includes/openai-client.php
@@ -1,0 +1,3 @@
+<?php
+// Placeholder for OpenAI helper functions
+// This file can be expanded to include authentication wrappers or other utilities.

--- a/lucidus-terminal-pro/lucidus-terminal.php
+++ b/lucidus-terminal-pro/lucidus-terminal.php
@@ -1,0 +1,55 @@
+<?php
+/*
+Plugin Name: Lucidus Terminal Pro
+Description: AI command center for WordPress.
+Version: 0.1
+*/
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+define( 'LUCIDUS_DIR', plugin_dir_path( __FILE__ ) );
+
+// Admin menu
+add_action( 'admin_menu', 'lucidus_add_admin_menu' );
+function lucidus_add_admin_menu() {
+    add_menu_page( 'Lucidus Terminal', 'Lucidus Terminal', 'manage_options', 'lucidus-terminal', 'lucidus_voice_settings_page' );
+    add_submenu_page( 'lucidus-terminal', 'Voice Settings', 'Voice Settings', 'manage_options', 'lucidus-voice-settings', 'lucidus_voice_settings_page' );
+}
+
+function lucidus_voice_settings_page() {
+    require_once LUCIDUS_DIR . 'admin/voice-settings.php';
+}
+
+// Ajax handler for testing voice
+add_action( 'wp_ajax_lucidus_test_voice', 'lucidus_test_voice_handler' );
+function lucidus_test_voice_handler() {
+    $model  = get_option( 'lucidus_voice_model', 'nova' );
+    $speed  = floatval( get_option( 'lucidus_voice_speed', 1.0 ) );
+    $pitch  = floatval( get_option( 'lucidus_voice_pitch', 0 ) );
+    $text   = get_option( 'lucidus_voice_prompt', 'Lucidus speaks...' );
+
+    $api_key = get_option( 'lucidus_openai_api_key' );
+    if ( empty( $api_key ) ) {
+        wp_die( 'Missing API key' );
+    }
+
+    $response = wp_remote_post( 'https://api.openai.com/v1/audio/speech', array(
+        'headers' => array(
+            'Authorization' => 'Bearer ' . $api_key,
+            'Content-Type'  => 'application/json',
+        ),
+        'body'    => wp_json_encode( array(
+            'model' => 'tts-' . $model,
+            'input' => $text,
+            'voice' => $model,
+            'speed' => $speed,
+            'pitch' => $pitch,
+        ) ),
+    ) );
+
+    header( 'Content-Type: audio/mpeg' );
+    echo wp_remote_retrieve_body( $response );
+    wp_die();
+}

--- a/lucidus-terminal-pro/readme.txt
+++ b/lucidus-terminal-pro/readme.txt
@@ -1,0 +1,8 @@
+=== Lucidus Terminal Pro ===
+Contributors: lucidus
+Requires at least: 5.0
+Tested up to: 6.4
+Stable tag: 0.1
+License: MIT
+
+The Lucidus Terminal Pro plugin integrates AI tools with WordPress.


### PR DESCRIPTION
## Summary
- add Lucidus Terminal Pro plugin skeleton
- implement admin voice settings form with sliders and prompt
- store settings via `update_option`
- include AJAX handler using OpenAI TTS to play voice in browser

## Testing
- `php -l lucidus-terminal-pro/lucidus-terminal.php`
- `php -l lucidus-terminal-pro/admin/voice-settings.php`
- `php -l lucidus-terminal-pro/includes/openai-client.php`


------
https://chatgpt.com/codex/tasks/task_e_68477139c22c8327a4cc4d4fa06d3976