### PR TITLE
Add DBS Membership Core plugin

### DIFF
--- a/dbs-membership-core/admin/editor.php
+++ b/dbs-membership-core/admin/editor.php
@@ -1,0 +1,46 @@
+<?php
+if (!current_user_can('manage_options')) {
+    return;
+}
+
+$user_id = isset($_GET['user_id']) ? intval($_GET['user_id']) : 0;
+$user = get_userdata($user_id);
+if (!$user) {
+    echo '<div class="notice notice-error"><p>User not found.</p></div>';
+    return;
+}
+
+if (isset($_POST['dbs_mc_editor_nonce']) && check_admin_referer('dbs_mc_save_profile', 'dbs_mc_editor_nonce')) {
+    update_user_meta($user_id, 'dbs_latin_name', sanitize_text_field($_POST['dbs_latin_name']));
+    dbs_mc_assign_rank($user_id, intval($_POST['dbs_rank']));
+    dbs_mc_set_behavior_tags($user_id, explode(',', $_POST['dbs_behavior_tags']));
+    dbs_mc_write_profile($user_id);
+    dbs_mc_notify_lucidus($user_id);
+    echo '<div class="updated"><p>Profile saved.</p></div>';
+}
+
+$rank = get_user_meta($user_id, 'dbs_rank', true);
+$latin = get_user_meta($user_id, 'dbs_latin_name', true);
+$tags = implode(',', dbs_mc_get_behavior_tags($user_id));
+?>
+<div class="wrap">
+    <h1>Edit Member: <?php echo esc_html($user->user_login); ?></h1>
+    <form method="post">
+        <?php wp_nonce_field('dbs_mc_save_profile', 'dbs_mc_editor_nonce'); ?>
+        <table class="form-table">
+            <tr>
+                <th><label for="dbs_latin_name">Latin Name</label></th>
+                <td><input type="text" name="dbs_latin_name" id="dbs_latin_name" value="<?php echo esc_attr($latin); ?>" class="regular-text"></td>
+            </tr>
+            <tr>
+                <th><label for="dbs_rank">Rank</label></th>
+                <td><input type="number" name="dbs_rank" id="dbs_rank" value="<?php echo esc_attr($rank); ?>"></td>
+            </tr>
+            <tr>
+                <th><label for="dbs_behavior_tags">Behavior Tags</label></th>
+                <td><input type="text" name="dbs_behavior_tags" id="dbs_behavior_tags" value="<?php echo esc_attr($tags); ?>" class="regular-text"></td>
+            </tr>
+        </table>
+        <?php submit_button(); ?>
+    </form>
+</div>

--- a/dbs-membership-core/admin/members.php
+++ b/dbs-membership-core/admin/members.php
@@ -1,0 +1,24 @@
+<?php
+if (!current_user_can('manage_options')) {
+    return;
+}
+
+$users = get_users();
+?>
+<div class="wrap">
+    <h1>DBS Members</h1>
+    <table class="widefat">
+        <thead>
+            <tr><th>User</th><th>Latin Name</th><th>Rank</th></tr>
+        </thead>
+        <tbody>
+            <?php foreach ($users as $user) : ?>
+                <tr>
+                    <td><?php echo esc_html($user->user_login); ?></td>
+                    <td><?php echo esc_html(get_user_meta($user->ID, 'dbs_latin_name', true)); ?></td>
+                    <td><?php echo esc_html(get_user_meta($user->ID, 'dbs_rank', true)); ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>

--- a/dbs-membership-core/admin/settings.php
+++ b/dbs-membership-core/admin/settings.php
@@ -1,0 +1,24 @@
+<?php
+if (!current_user_can('manage_options')) {
+    return;
+}
+
+if (isset($_POST['dbs_mc_settings_nonce']) && check_admin_referer('dbs_mc_save_settings', 'dbs_mc_settings_nonce')) {
+    update_option('dbs_mc_archetypes', sanitize_text_field($_POST['dbs_mc_archetypes']));
+    echo '<div class="updated"><p>Settings saved.</p></div>';
+}
+$archetypes = get_option('dbs_mc_archetypes', 'warrior, mage, rogue');
+?>
+<div class="wrap">
+    <h1>DBS Membership Settings</h1>
+    <form method="post">
+        <?php wp_nonce_field('dbs_mc_save_settings', 'dbs_mc_settings_nonce'); ?>
+        <table class="form-table">
+            <tr>
+                <th scope="row"><label for="dbs_mc_archetypes">Archetypes</label></th>
+                <td><input name="dbs_mc_archetypes" type="text" id="dbs_mc_archetypes" value="<?php echo esc_attr($archetypes); ?>" class="regular-text"></td>
+            </tr>
+        </table>
+        <?php submit_button(); ?>
+    </form>
+</div>

--- a/dbs-membership-core/assets/css/initiation.css
+++ b/dbs-membership-core/assets/css/initiation.css
@@ -1,0 +1,10 @@
+.dbs-initiation-form {
+    background: #111;
+    color: #eee;
+    padding: 20px;
+}
+.dbs-confirmation {
+    background: #222;
+    color: #fff;
+    padding: 20px;
+}

--- a/dbs-membership-core/assets/js/initiation.js
+++ b/dbs-membership-core/assets/js/initiation.js
@@ -1,0 +1,3 @@
+jQuery(document).ready(function($){
+    console.log('DBS initiation loaded');
+});

--- a/dbs-membership-core/dbs-membership-core.php
+++ b/dbs-membership-core/dbs-membership-core.php
@@ -1,0 +1,62 @@
+<?php
+/*
+Plugin Name: DBS Membership Core
+Description: Handles member onboarding and memory management for the Dead Bastard Society.
+Version: 0.1.0
+Author: Dead Bastard Society
+*/
+
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly.
+}
+
+define('DBS_MC_PLUGIN_DIR', plugin_dir_path(__FILE__));
+define('DBS_MC_VERSION', '0.1.0');
+
+require_once DBS_MC_PLUGIN_DIR . 'includes/latin-name-generator.php';
+require_once DBS_MC_PLUGIN_DIR . 'includes/rank-logic.php';
+require_once DBS_MC_PLUGIN_DIR . 'includes/profile-writer.php';
+require_once DBS_MC_PLUGIN_DIR . 'includes/geo-name-engine.php';
+require_once DBS_MC_PLUGIN_DIR . 'includes/ai-bridge.php';
+require_once DBS_MC_PLUGIN_DIR . 'includes/behavior-tags.php';
+
+// Register activation hook.
+function dbs_mc_activate() {
+    // Setup default options if needed.
+}
+register_activation_hook(__FILE__, 'dbs_mc_activate');
+
+// Register shortcode for initiation form.
+function dbs_mc_register_shortcodes() {
+    add_shortcode('dbs_initiation_form', 'dbs_mc_render_initiation_form');
+}
+add_action('init', 'dbs_mc_register_shortcodes');
+
+// Enqueue frontend assets.
+function dbs_mc_enqueue_assets() {
+    wp_enqueue_style('dbs-initiation-css', plugins_url('assets/css/initiation.css', __FILE__), [], DBS_MC_VERSION);
+    wp_enqueue_script('dbs-initiation-js', plugins_url('assets/js/initiation.js', __FILE__), ['jquery'], DBS_MC_VERSION, true);
+}
+add_action('wp_enqueue_scripts', 'dbs_mc_enqueue_assets');
+
+// Render initiation form.
+function dbs_mc_render_initiation_form() {
+    ob_start();
+    include DBS_MC_PLUGIN_DIR . 'frontend/initiation-form.php';
+    return ob_get_clean();
+}
+
+// Admin menus.
+function dbs_mc_admin_menu() {
+    add_menu_page('DBS Members', 'DBS Members', 'manage_options', 'dbs-members', 'dbs_mc_members_page');
+    add_submenu_page('dbs-members', 'Settings', 'Settings', 'manage_options', 'dbs-members-settings', 'dbs_mc_settings_page');
+}
+add_action('admin_menu', 'dbs_mc_admin_menu');
+
+function dbs_mc_members_page() {
+    include DBS_MC_PLUGIN_DIR . 'admin/members.php';
+}
+
+function dbs_mc_settings_page() {
+    include DBS_MC_PLUGIN_DIR . 'admin/settings.php';
+}

--- a/dbs-membership-core/frontend/confirmation.php
+++ b/dbs-membership-core/frontend/confirmation.php
@@ -1,0 +1,11 @@
+<?php
+$user_id = get_current_user_id();
+$latin = get_user_meta($user_id, 'dbs_latin_name', true);
+$rank = get_user_meta($user_id, 'dbs_rank', true);
+$geo = get_user_meta($user_id, 'dbs_geo_name', true);
+?>
+<div class="dbs-confirmation">
+    <h2>Welcome, <?php echo esc_html($latin); ?></h2>
+    <p>Your rank: <?php echo esc_html($rank); ?></p>
+    <p>Your town: <?php echo esc_html($geo); ?></p>
+</div>

--- a/dbs-membership-core/frontend/initiation-form.php
+++ b/dbs-membership-core/frontend/initiation-form.php
@@ -1,0 +1,36 @@
+<?php
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['dbs_mc_initiate_nonce']) && wp_verify_nonce($_POST['dbs_mc_initiate_nonce'], 'dbs_mc_initiate')) {
+    $user_id = get_current_user_id();
+    if ($user_id) {
+        $archetype = sanitize_text_field($_POST['dbs_archetype']);
+        $town = sanitize_text_field($_POST['dbs_town']);
+        $latin_name = dbs_mc_generate_latin_name($archetype);
+        $geo_name = dbs_mc_generate_geo_name($town);
+
+        update_user_meta($user_id, 'dbs_archetype', $archetype);
+        update_user_meta($user_id, 'dbs_town', $town);
+        update_user_meta($user_id, 'dbs_latin_name', $latin_name);
+        update_user_meta($user_id, 'dbs_geo_name', $geo_name);
+        dbs_mc_assign_rank($user_id);
+        dbs_mc_write_profile($user_id);
+        dbs_mc_notify_lucidus($user_id);
+        wp_redirect(add_query_arg('dbs_confirm', 1, get_permalink()));
+        exit;
+    } else {
+        echo '<p>You must be logged in.</p>';
+    }
+}
+?>
+<form method="post" class="dbs-initiation-form">
+    <?php wp_nonce_field('dbs_mc_initiate', 'dbs_mc_initiate_nonce'); ?>
+    <p>
+        <label for="dbs_archetype">Archetype</label>
+        <input type="text" name="dbs_archetype" id="dbs_archetype" required>
+    </p>
+    <p>
+        <label for="dbs_town">Town</label>
+        <input type="text" name="dbs_town" id="dbs_town" required>
+    </p>
+    <p><button type="submit">Join DBS</button></p>
+</form>
+<?php if (isset($_GET['dbs_confirm'])) { include DBS_MC_PLUGIN_DIR . 'frontend/confirmation.php'; } ?>

--- a/dbs-membership-core/includes/ai-bridge.php
+++ b/dbs-membership-core/includes/ai-bridge.php
@@ -1,0 +1,9 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+function dbs_mc_notify_lucidus($user_id) {
+    // Placeholder: hook into Lucidus API or trigger action.
+    do_action('dbs_mc_profile_saved', $user_id);
+}

--- a/dbs-membership-core/includes/behavior-tags.php
+++ b/dbs-membership-core/includes/behavior-tags.php
@@ -1,0 +1,13 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+function dbs_mc_set_behavior_tags($user_id, $tags = []) {
+    update_user_meta($user_id, 'dbs_behavior_tags', array_map('sanitize_text_field', $tags));
+}
+
+function dbs_mc_get_behavior_tags($user_id) {
+    $tags = get_user_meta($user_id, 'dbs_behavior_tags', true);
+    return is_array($tags) ? $tags : [];
+}

--- a/dbs-membership-core/includes/geo-name-engine.php
+++ b/dbs-membership-core/includes/geo-name-engine.php
@@ -1,0 +1,10 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+function dbs_mc_generate_geo_name($town) {
+    $suffixes = ['Blaze', 'Fog', 'Field', 'Burn', 'Munch'];
+    $suffix = $suffixes[array_rand($suffixes)];
+    return ucfirst($town) . ' ' . $suffix;
+}

--- a/dbs-membership-core/includes/latin-name-generator.php
+++ b/dbs-membership-core/includes/latin-name-generator.php
@@ -1,0 +1,12 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+function dbs_mc_generate_latin_name($archetype = '') {
+    $prefixes = ['Chronicus', 'Nastyus', 'Randallus', 'Foglor', 'Smokus'];
+    $suffixes = ['Blazion', 'Foglor', 'Dankson', 'Blaze', 'Doobius'];
+    $prefix = $prefixes[array_rand($prefixes)];
+    $suffix = $suffixes[array_rand($suffixes)];
+    return "$prefix $suffix";
+}

--- a/dbs-membership-core/includes/profile-writer.php
+++ b/dbs-membership-core/includes/profile-writer.php
@@ -1,0 +1,30 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+function dbs_mc_write_profile($user_id) {
+    $user = get_userdata($user_id);
+    if (!$user) {
+        return false;
+    }
+
+    $profile = [
+        'user_id' => $user_id,
+        'latin_name' => get_user_meta($user_id, 'dbs_latin_name', true),
+        'archetype' => get_user_meta($user_id, 'dbs_archetype', true),
+        'geo_name' => get_user_meta($user_id, 'dbs_geo_name', true),
+        'rank' => intval(get_user_meta($user_id, 'dbs_rank', true)),
+        'behavior_tags' => get_user_meta($user_id, 'dbs_behavior_tags', true)
+    ];
+
+    $upload_dir = wp_upload_dir();
+    $dir = trailingslashit($upload_dir['basedir']) . 'dbs-library/memory-archive/profiles/';
+    if (!file_exists($dir)) {
+        wp_mkdir_p($dir);
+    }
+    $file = $dir . $user->user_login . '.json';
+    file_put_contents($file, wp_json_encode($profile, JSON_PRETTY_PRINT));
+
+    return $file;
+}

--- a/dbs-membership-core/includes/rank-logic.php
+++ b/dbs-membership-core/includes/rank-logic.php
@@ -1,0 +1,15 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+function dbs_mc_get_default_rank() {
+    return 1; // Initiate rank
+}
+
+function dbs_mc_assign_rank($user_id, $rank = null) {
+    if (!$rank) {
+        $rank = dbs_mc_get_default_rank();
+    }
+    update_user_meta($user_id, 'dbs_rank', intval($rank));
+}

--- a/dbs-membership-core/readme.txt
+++ b/dbs-membership-core/readme.txt
@@ -1,0 +1,8 @@
+=== DBS Membership Core ===
+Contributors: Dead Bastard Society
+Requires at least: 5.5
+Tested up to: 6.4
+Stable tag: 0.1.0
+License: MIT
+
+This plugin handles membership onboarding for the Dead Bastard Society.

--- a/dbs-membership-core/uninstall.php
+++ b/dbs-membership-core/uninstall.php
@@ -1,0 +1,7 @@
+<?php
+if (!defined('WP_UNINSTALL_PLUGIN')) {
+    exit;
+}
+// Cleanup options and user meta.
+delete_option('dbs_mc_archetypes');
+// Additional cleanup can be added here.


### PR DESCRIPTION
## Summary
- add new DBS Membership Core plugin skeleton
- add admin pages, frontend forms, assets, and include files

## Testing
- `php -l dbs-membership-core/dbs-membership-core.php`
- `php -l dbs-membership-core/includes/profile-writer.php`
- `php -l dbs-membership-core/frontend/initiation-form.php`
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684773f2d7a48327b36a4228d774baef