### PR TITLE
Add custom post types for quest system

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,13 @@ The Lucidus plugin is the AI-powered command center of the **Dead Bastard Societ
 - Voice input/output (OpenAI + ElevenLabs)
 - Memory injection + archive tools
 - File browser + diagnostics
-- Scroll-unlock engine (coming soon)
+- Scroll-unlock engine with ranks
+- Badge and patch rewards
 - Full DBS universe integration
 
 ## 📁 Directory Structure
 lucidus-terminal-pro/
-├── admin/
-├── assets/
-├── core/
-├── templates/
-├── lucidus-terminal.php
-├── readme.txt
+├── lucidus-terminal-pro.php
 └── README.md
 
 ## 🧠 Project Philosophy
@@ -31,6 +27,7 @@ Lucidus is not just a plugin — it’s a memory-wielding, stoner-prophet bastar
 2. Activate via WP Admin
 3. Configure API keys via **Lucidus Terminal → Settings**
 4. Speak to Lucidus. Fear the truth he reveals.
+5. Configure ranks, badges, patches and scrolls under their respective menus in WP Admin.
 
 ## 🪪 License
 

--- a/lucidus-terminal-pro/README.md
+++ b/lucidus-terminal-pro/README.md
@@ -1,0 +1,13 @@
+# Lucidus Terminal Pro
+
+This plugin powers the Dead Bastard Society universe with custom post types and quest logic.
+
+## Features
+
+- Custom post types: **badge**, **patch**, and **scroll**
+- Rank-based scroll unlocks
+- Displays earned badges and patches on member profiles
+
+## Installation
+
+Upload the `lucidus-terminal-pro` folder to your WordPress plugins directory and activate via the admin panel.

--- a/lucidus-terminal-pro/lucidus-terminal-pro.php
+++ b/lucidus-terminal-pro/lucidus-terminal-pro.php
@@ -1,0 +1,103 @@
+<?php
+/*
+Plugin Name: Lucidus Terminal Pro
+Description: Custom post types and quest system integration.
+Version: 0.1.0
+Author: Lucidus Bastardo
+*/
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Register custom post types: badge, patch, scroll.
+ */
+function lucidus_register_cpts() {
+    $common = array(
+        'public'       => true,
+        'show_in_menu' => true,
+        'supports'     => array( 'title', 'editor', 'thumbnail' ),
+    );
+
+    register_post_type( 'badge', array_merge( $common, array(
+        'label' => 'Badges',
+    ) ) );
+
+    register_post_type( 'patch', array_merge( $common, array(
+        'label' => 'Patches',
+    ) ) );
+
+    register_post_type( 'scroll', array_merge( $common, array(
+        'label' => 'Scrolls',
+    ) ) );
+}
+add_action( 'init', 'lucidus_register_cpts' );
+
+/**
+ * Add meta box for scroll rank requirement.
+ */
+function lucidus_scroll_meta_box() {
+    add_meta_box( 'lucidus-scroll-rank', 'Required Rank', 'lucidus_scroll_meta_box_cb', 'scroll', 'side' );
+}
+add_action( 'add_meta_boxes', 'lucidus_scroll_meta_box' );
+
+function lucidus_scroll_meta_box_cb( $post ) {
+    $value = get_post_meta( $post->ID, '_required_rank', true );
+    ?>
+    <label for="lucidus_required_rank">Rank needed to unlock</label>
+    <input type="number" name="lucidus_required_rank" id="lucidus_required_rank" value="<?php echo esc_attr( $value ); ?>" />
+    <?php
+}
+
+function lucidus_save_scroll_meta( $post_id ) {
+    if ( isset( $_POST['lucidus_required_rank'] ) ) {
+        update_post_meta( $post_id, '_required_rank', intval( $_POST['lucidus_required_rank'] ) );
+    }
+}
+add_action( 'save_post_scroll', 'lucidus_save_scroll_meta' );
+
+/**
+ * Check if a scroll is unlocked for a user.
+ *
+ * @param int $scroll_id
+ * @param int $user_id
+ * @return bool
+ */
+function lucidus_is_scroll_unlocked( $scroll_id, $user_id = 0 ) {
+    $user_id      = $user_id ? $user_id : get_current_user_id();
+    $required     = intval( get_post_meta( $scroll_id, '_required_rank', true ) );
+    $user_rank    = intval( get_user_meta( $user_id, 'lucidus_rank', true ) );
+    return $user_rank >= $required;
+}
+
+/**
+ * Display earned badges and patches on user profile screen.
+ */
+function lucidus_show_user_rewards( $user ) {
+    $badges  = (array) get_user_meta( $user->ID, 'lucidus_badges', true );
+    $patches = (array) get_user_meta( $user->ID, 'lucidus_patches', true );
+
+    echo '<h2>Lucidus Rewards</h2>';
+    echo '<h3>Badges</h3><ul>';
+    foreach ( $badges as $badge_id ) {
+        $post = get_post( $badge_id );
+        if ( $post ) {
+            echo '<li>' . esc_html( $post->post_title ) . '</li>';
+        }
+    }
+    echo '</ul>';
+
+    echo '<h3>Patches</h3><ul>';
+    foreach ( $patches as $patch_id ) {
+        $post = get_post( $patch_id );
+        if ( $post ) {
+            echo '<li>' . esc_html( $post->post_title ) . '</li>';
+        }
+    }
+    echo '</ul>';
+}
+add_action( 'show_user_profile', 'lucidus_show_user_rewards' );
+add_action( 'edit_user_profile', 'lucidus_show_user_rewards' );
+


### PR DESCRIPTION
## Summary
- add Lucidus Terminal Pro plugin skeleton
- support badge, patch, and scroll CPTs
- track rank-based quest unlocks via scroll metadata
- show earned badges and patches in user profiles
- update docs with new features

## Testing
- `php -l lucidus-terminal-pro/lucidus-terminal-pro.php`


------
https://chatgpt.com/codex/tasks/task_e_6847883f6d5083278fd7cece67d3407a