### PR TITLE
Add quest plugin with custom post types

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,21 @@ The Lucidus plugin is the AI-powered command center of the **Dead Bastard Societ
 - Voice input/output (OpenAI + ElevenLabs)
 - Memory injection + archive tools
 - File browser + diagnostics
-- Scroll-unlock engine (coming soon)
+- Scroll-unlock engine
+- Custom post types for badges, patches and scrolls
+- Quest system with rank progression
 - Full DBS universe integration
 
 ## 📁 Directory Structure
+```
 lucidus-terminal-pro/
-├── admin/
-├── assets/
-├── core/
-├── templates/
 ├── lucidus-terminal.php
-├── readme.txt
+├── templates/
+│   ├── single-badge.php
+│   ├── single-patch.php
+│   └── single-scroll.php
 └── README.md
+```
 
 ## 🧠 Project Philosophy
 
@@ -38,6 +41,5 @@ This project is licensed under the MIT License.
 
 ## 🧔 Built By
 
-Dr.G and Lucidus Bastardo  
+Dr.G and Lucidus Bastardo
 _“Let the smoke speak.”_
-

--- a/lucidus-terminal-pro/README.md
+++ b/lucidus-terminal-pro/README.md
@@ -1,0 +1,17 @@
+# Lucidus Terminal Pro
+
+This plugin registers custom post types for the Dead Bastard Society universe and implements basic quest logic for scroll completion and rank progression.
+
+## Features
+
+- Custom post types: **badge**, **patch**, **scroll**
+- Template overrides for each custom type
+- Quest system that increases a user's rank when a scroll is completed
+- Progress saved as JSON files in `/wp-content/dbs-library/`
+
+## Usage
+
+1. Upload `lucidus-terminal-pro` to your WordPress plugins directory.
+2. Activate the plugin.
+3. Create scroll posts and mark them complete via the provided form on the single scroll template.
+4. Completed scrolls increase a user's rank and store progress in the DBS library folder.

--- a/lucidus-terminal-pro/lucidus-terminal.php
+++ b/lucidus-terminal-pro/lucidus-terminal.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Plugin Name: Lucidus Terminal Pro
+ * Description: Core features for the DBS universe including custom post types and quest logic.
+ * Version: 0.1.0
+ * Author: Lucidus Bastardo
+ * License: MIT
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+/**
+ * Register custom post types.
+ */
+function lucidus_register_custom_post_types() {
+    // Badge post type.
+    register_post_type( 'badge', array(
+        'labels' => array(
+            'name' => 'Badges',
+            'singular_name' => 'Badge'
+        ),
+        'public' => true,
+        'has_archive' => true,
+        'show_in_rest' => true,
+        'supports' => array( 'title', 'editor', 'thumbnail' ),
+    ) );
+
+    // Patch post type.
+    register_post_type( 'patch', array(
+        'labels' => array(
+            'name' => 'Patches',
+            'singular_name' => 'Patch'
+        ),
+        'public' => true,
+        'has_archive' => true,
+        'show_in_rest' => true,
+        'supports' => array( 'title', 'editor', 'thumbnail' ),
+    ) );
+
+    // Scroll post type.
+    register_post_type( 'scroll', array(
+        'labels' => array(
+            'name' => 'Scrolls',
+            'singular_name' => 'Scroll'
+        ),
+        'public' => true,
+        'has_archive' => true,
+        'show_in_rest' => true,
+        'supports' => array( 'title', 'editor', 'thumbnail', 'custom-fields' ),
+    ) );
+}
+add_action( 'init', 'lucidus_register_custom_post_types' );
+
+/**
+ * Template loader for custom post types.
+ */
+function lucidus_custom_templates( $template ) {
+    if ( is_singular( 'badge' ) ) {
+        $plugin_template = plugin_dir_path( __FILE__ ) . 'templates/single-badge.php';
+        if ( file_exists( $plugin_template ) ) {
+            return $plugin_template;
+        }
+    }
+
+    if ( is_singular( 'patch' ) ) {
+        $plugin_template = plugin_dir_path( __FILE__ ) . 'templates/single-patch.php';
+        if ( file_exists( $plugin_template ) ) {
+            return $plugin_template;
+        }
+    }
+
+    if ( is_singular( 'scroll' ) ) {
+        $plugin_template = plugin_dir_path( __FILE__ ) . 'templates/single-scroll.php';
+        if ( file_exists( $plugin_template ) ) {
+            return $plugin_template;
+        }
+    }
+
+    return $template;
+}
+add_filter( 'template_include', 'lucidus_custom_templates' );
+
+/**
+ * Simple quest logic: when a scroll is marked complete, increase user rank and
+ * persist progress to /wp-content/dbs-library/.
+ */
+function lucidus_handle_scroll_completion( $post_id, $post, $update ) {
+    if ( $post->post_type !== 'scroll' ) {
+        return;
+    }
+
+    if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+        return;
+    }
+
+    // Check if scroll was marked as complete via custom field 'scroll_completed'.
+    $completed = get_post_meta( $post_id, 'scroll_completed', true );
+    if ( $completed ) {
+        $user_id = get_current_user_id();
+        if ( ! $user_id ) {
+            return;
+        }
+
+        $current_rank = (int) get_user_meta( $user_id, 'lucidus_rank', true );
+        $new_rank = $current_rank + 1;
+        update_user_meta( $user_id, 'lucidus_rank', $new_rank );
+
+        $progress = array(
+            'user_id' => $user_id,
+            'scroll_id' => $post_id,
+            'rank' => $new_rank,
+            'completed_at' => current_time( 'mysql' ),
+        );
+        lucidus_store_progress_json( $progress );
+    }
+}
+add_action( 'save_post', 'lucidus_handle_scroll_completion', 10, 3 );
+
+/**
+ * Store progress as JSON in wp-content/dbs-library
+ */
+function lucidus_store_progress_json( $data ) {
+    $dir = trailingslashit( ABSPATH . 'wp-content/dbs-library' );
+    if ( ! wp_mkdir_p( $dir ) ) {
+        return;
+    }
+
+    $filename = 'progress-' . time() . '-' . wp_generate_uuid4() . '.json';
+    $filepath = $dir . $filename;
+    $json = wp_json_encode( $data, JSON_PRETTY_PRINT );
+    file_put_contents( $filepath, $json );
+}
+
+/**
+ * Process scroll completion form submission.
+ */
+function lucidus_process_scroll_completion() {
+    if ( isset( $_POST['complete_scroll'] ) && isset( $_POST['complete_scroll_nonce'] ) && wp_verify_nonce( $_POST['complete_scroll_nonce'], 'complete_scroll' ) ) {
+        if ( is_singular( 'scroll' ) ) {
+            $post_id = get_the_ID();
+            update_post_meta( $post_id, 'scroll_completed', 1 );
+        }
+    }
+}
+add_action( 'template_redirect', 'lucidus_process_scroll_completion' );

--- a/lucidus-terminal-pro/templates/single-badge.php
+++ b/lucidus-terminal-pro/templates/single-badge.php
@@ -1,0 +1,8 @@
+<?php get_header(); ?>
+<main id="primary" class="site-main">
+    <h1><?php the_title(); ?></h1>
+    <div class="entry-content">
+        <?php the_content(); ?>
+    </div>
+</main>
+<?php get_footer(); ?>

--- a/lucidus-terminal-pro/templates/single-patch.php
+++ b/lucidus-terminal-pro/templates/single-patch.php
@@ -1,0 +1,8 @@
+<?php get_header(); ?>
+<main id="primary" class="site-main">
+    <h1><?php the_title(); ?></h1>
+    <div class="entry-content">
+        <?php the_content(); ?>
+    </div>
+</main>
+<?php get_footer(); ?>

--- a/lucidus-terminal-pro/templates/single-scroll.php
+++ b/lucidus-terminal-pro/templates/single-scroll.php
@@ -1,0 +1,12 @@
+<?php get_header(); ?>
+<main id="primary" class="site-main">
+    <h1><?php the_title(); ?></h1>
+    <div class="entry-content">
+        <?php the_content(); ?>
+        <form method="post">
+            <?php wp_nonce_field('complete_scroll','complete_scroll_nonce'); ?>
+            <input type="submit" name="complete_scroll" value="Complete Scroll">
+        </form>
+    </div>
+</main>
+<?php get_footer(); ?>


### PR DESCRIPTION
## Summary
- build `lucidus-terminal-pro` plugin
- register custom post types (badge, patch, scroll)
- add template overrides for CPTs
- implement scroll completion logic with rank progression
- store quest progress JSON under `/wp-content/dbs-library/`
- document features in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6847881676dc8327b778ab4d3d6643b8