### PR TITLE
Add skeleton plugin for prophecy engine

### DIFF
--- a/lucidus-prophecy-engine/assets/css/prophecy-style.css
+++ b/lucidus-prophecy-engine/assets/css/prophecy-style.css
@@ -1,0 +1,1 @@
+/* Placeholder CSS for prophecy room. */

--- a/lucidus-prophecy-engine/assets/js/prophecy-ui.js
+++ b/lucidus-prophecy-engine/assets/js/prophecy-ui.js
@@ -1,0 +1,1 @@
+// Placeholder JS for prophecy form handling.

--- a/lucidus-prophecy-engine/includes/astrology.php
+++ b/lucidus-prophecy-engine/includes/astrology.php
@@ -1,0 +1,3 @@
+<?php
+// Placeholder for astrology calculations.
+?>

--- a/lucidus-prophecy-engine/includes/fungal-prophecy.php
+++ b/lucidus-prophecy-engine/includes/fungal-prophecy.php
@@ -1,0 +1,3 @@
+<?php
+// Placeholder for fungal/plant divination.
+?>

--- a/lucidus-prophecy-engine/includes/latin-quote-generator.php
+++ b/lucidus-prophecy-engine/includes/latin-quote-generator.php
@@ -1,0 +1,3 @@
+<?php
+// Placeholder for Latin phrase generator.
+?>

--- a/lucidus-prophecy-engine/includes/numerology.php
+++ b/lucidus-prophecy-engine/includes/numerology.php
@@ -1,0 +1,3 @@
+<?php
+// Placeholder for numerology logic.
+?>

--- a/lucidus-prophecy-engine/includes/parable-fusion.php
+++ b/lucidus-prophecy-engine/includes/parable-fusion.php
@@ -1,0 +1,3 @@
+<?php
+// Placeholder for religious parable mapper.
+?>

--- a/lucidus-prophecy-engine/includes/prophecy-form.php
+++ b/lucidus-prophecy-engine/includes/prophecy-form.php
@@ -1,0 +1,30 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+function lpe_render_prophecy_form() {
+    ob_start();
+    ?>
+    <form id="lpe-prophecy-form">
+        <p><label>Username / Latin Name<br>
+            <input type="text" name="lpe_username" required></label></p>
+        <p><label>Date of Birth<br>
+            <input type="date" name="lpe_dob" required></label></p>
+        <p><label>Town / Country<br>
+            <input type="text" name="lpe_town" required></label></p>
+        <p>Archetype:<br>
+            <label><input type="radio" name="lpe_archetype" value="Dub" required> Dub</label>
+            <label><input type="radio" name="lpe_archetype" value="Randall"> Randall</label>
+            <label><input type="radio" name="lpe_archetype" value="Nasty P"> Nasty P</label>
+        </p>
+        <p><label>Favorite Strain / Plant (optional)<br>
+            <input type="text" name="lpe_strain"></label></p>
+        <p><label>Mood / Question (optional)<br>
+            <textarea name="lpe_question"></textarea></label></p>
+        <p><button type="submit">Reveal Prophecy</button></p>
+    </form>
+    <div id="lpe-prophecy-output"></div>
+    <?php
+    return ob_get_clean();
+}

--- a/lucidus-prophecy-engine/includes/prophecy-generator.php
+++ b/lucidus-prophecy-engine/includes/prophecy-generator.php
@@ -1,0 +1,9 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+function lpe_generate_prophecy($data) {
+    // Placeholder function to combine all modules.
+    return 'Prophecy generation not yet implemented.';
+}

--- a/lucidus-prophecy-engine/includes/tarot-engine.php
+++ b/lucidus-prophecy-engine/includes/tarot-engine.php
@@ -1,0 +1,3 @@
+<?php
+// Placeholder for tarot/rune draw logic.
+?>

--- a/lucidus-prophecy-engine/includes/voice-playback.js
+++ b/lucidus-prophecy-engine/includes/voice-playback.js
@@ -1,0 +1,1 @@
+// Placeholder for TTS playback logic.

--- a/lucidus-prophecy-engine/lucidus-prophecy-engine.php
+++ b/lucidus-prophecy-engine/lucidus-prophecy-engine.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Plugin Name: Lucidus Prophecy Engine
+ * Description: Generates custom prophetic scrolls combining astrology, numerology, tarot, fungal wisdom, AI parables, and Latin seals.
+ * Version: 0.1.0
+ * Author: Dead Bastard Society
+ * License: MIT
+ */
+
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly.
+}
+
+// Define plugin path constant.
+define('LPE_PATH', plugin_dir_path(__FILE__));
+
+define('LPE_URL', plugin_dir_url(__FILE__));
+
+// Include core files.
+require_once LPE_PATH . 'includes/prophecy-form.php';
+require_once LPE_PATH . 'includes/prophecy-generator.php';
+
+// Shortcode to render prophecy form.
+add_shortcode('lucidus_prophecy_form', 'lpe_render_prophecy_form');

--- a/lucidus-prophecy-engine/readme.txt
+++ b/lucidus-prophecy-engine/readme.txt
@@ -1,0 +1,8 @@
+=== Lucidus Prophecy Engine ===
+Contributors: Dead Bastard Society
+Requires at least: 5.8
+Tested up to: 6.4
+Stable tag: 0.1.0
+License: MIT
+
+A prophetic generator plugin blending astrology, numerology, tarot, and AI-driven parables.

--- a/lucidus-prophecy-engine/templates/prophecy-room.php
+++ b/lucidus-prophecy-engine/templates/prophecy-room.php
@@ -1,0 +1,3 @@
+<div class="lpe-prophecy-room">
+    <p>Your prophecy will appear here.</p>
+</div>


### PR DESCRIPTION
## Summary
- add `lucidus-prophecy-engine` WordPress plugin directory
- stub out loader, form, generation logic, and modules
- include placeholder assets and template

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684855e2e5a88327bb6225cb6dc8a214