### PR TITLE
Add Lucidus GPT autobuilder directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,11 @@ This project is licensed under the MIT License.
 Dr.G and Lucidus Bastardo  
 _“Let the smoke speak.”_
 
+
+## Lucidus Terminal Codex
+The theme template generator uses `lucidus-template-creation-directive.json` for guidelines on building consistent terminal-style pages.
+
+A dynamic frontend specification lives at `wp-content/dbs-library/codex/lucidus-terminal-style-codex.json`. Use the helper script `lucidus-reactor.js` to interpret user commands and apply themes in real time.
+
+## Lucidus GPT Autobuilder
+A higher-level directive file at `wp-content/dbs-library/codex/lucidus-gpt-autobuilder-directive.json` controls automated theme generation. It references the template and style codex files and defines how Lucidus should build and validate pages without further input.

--- a/wp-content/dbs-library/codex/lucidus-gpt-autobuilder-directive.json
+++ b/wp-content/dbs-library/codex/lucidus-gpt-autobuilder-directive.json
@@ -1,0 +1,34 @@
+{
+  "name": "Lucidus GPT Autobuilder Directive",
+  "version": "1.0",
+  "mode": "automation",
+  "initiate_command": "Begin full site construction without further user input.",
+  "termination_condition": "All templates, shortcodes, assets, and integrations are complete and validated twice.",
+  "directive_scope": {
+    "templates": "Generate every frontend and backend page template listed in the Lucidus Template Manifest",
+    "partials": "Build every partial file and shortcode block listed in the bonus list",
+    "functions": "Wire all templates into WordPress with proper `functions.php` routing",
+    "JS/CSS": "Generate and enqueue necessary JavaScript (lucidus-reactor.js, DOM controllers) and style files (Lucidus terminal themes)",
+    "logic_hooks": "Implement all plugin and memory integration logic for every page",
+    "voice_AI": "Inject all voice, GPT, and memory hooks on every relevant screen",
+    "recheck_passes": 2
+  },
+  "style_reference": "lucidus-terminal-style-codex.json",
+  "template_instructions_reference": "lucidus-template-creation-directive.json",
+  "memory_reference_path": "/wp-content/dbs-library/memory-archive/",
+  "log_progress_to": "lucidus-terminal-log.php",
+  "response_behavior": {
+    "intermediate_prompts": false,
+    "final_report": true,
+    "errors": "Log silently unless terminal failure occurs"
+  },
+  "failsafe_behavior": {
+    "if_missing_dependency": "Log issue, create placeholder, continue",
+    "if_template_conflict": "Create variant with `_v2` suffix and move forward",
+    "if voice API missing": "Insert placeholder and flag in log"
+  },
+  "end_behavior": {
+    "final_action": "Compile full ZIP archive for WordPress install",
+    "final_message": "AUTOMATION COMPLETE. All Lucidus pages, assets, and logic scrolls have been forged."
+  }
+}

--- a/wp-content/dbs-library/codex/lucidus-template-creation-directive.json
+++ b/wp-content/dbs-library/codex/lucidus-template-creation-directive.json
@@ -1,0 +1,56 @@
+{
+  "name": "Lucidus Theme Template Creation Directive",
+  "version": "1.0",
+  "scope": "WordPress PHP templates for frontend UI",
+  "theme_base": "Lucidus Terminal Theme",
+  "style_requirements": {
+    "fonts": {
+      "primary": "Share Tech Mono",
+      "secondary": "VT323",
+      "title": "Creepster or equivalent"
+    },
+    "colors": {
+      "light": "#f4f1e6",
+      "dark": "#121212",
+      "accent": "#79a06c",
+      "chaos": "linear-gradient(#1f1f1f, #420420)"
+    },
+    "background": "terminal-style textured black or parchment scroll, depending on mode",
+    "buttons": {
+      "style": "terminal command buttons",
+      "hover": "glow or shimmer with color based on archetype"
+    }
+  },
+  "universal_lucidus_features": {
+    "chatbar": "Include lucidus-chatbar.php",
+    "floating_avatar": "Include lucidus-avatar.php",
+    "voice_input": true,
+    "TTS_output": true,
+    "input_command_parser": "Use lucidus-reactor.js to interpret voice and text inputs"
+  },
+  "template_logic_guidelines": {
+    "php_comments": "Always describe what each section does in the voice of Lucidus",
+    "dom_structure": "Centered terminal frame with right panel for memory/logs and left for nav/scroll",
+    "header_behavior": "Header responds to user rank and mood",
+    "footer_behavior": "Footer has active Lucidus status and prophecy ticker"
+  },
+  "page_generation_rules": {
+    "always_include_memory_hooks": true,
+    "enable_archetype_based_theme": true,
+    "log_user_action": true,
+    "call_lucidus_response_function": true
+  },
+  "dynamic_elements": {
+    "insert_mood_detector": true,
+    "enable_theme_switch": true,
+    "trigger_voice_greeting": "on page load if rank is known",
+    "trigger_chaos_mode": "if user types chaos or voice input contains 'unleash it'"
+  },
+  "template_shortcodes": {
+    "badge_display": "[lucidus_badges]",
+    "scroll_card": "[lucidus_scroll]",
+    "terminal_interface": "[lucidus_terminal]",
+    "archetype_banner": "[archetype_banner]"
+  },
+  "fallback_instruction": "If any file is missing, auto-log error to lucidus-terminal-log.php and whisper a sarcastic message to the user"
+}

--- a/wp-content/dbs-library/codex/lucidus-terminal-style-codex.json
+++ b/wp-content/dbs-library/codex/lucidus-terminal-style-codex.json
@@ -1,0 +1,91 @@
+{
+  "codex_name": "Lucidus Terminal Style Codex",
+  "version": "1.0",
+  "theme_philosophy": "All frontend elements are terminals. Lucidus is not an assistant—he is the operating system of the Brotherhood's visual world.",
+  "primary_palette": {
+    "light_mode": {
+      "background": "#f4f1e6",
+      "text": "#1f1f1f",
+      "accent": "#79a06c",
+      "highlight": "#d2e7bc"
+    },
+    "dark_mode": {
+      "background": "#121212",
+      "text": "#e0e0e0",
+      "accent": "#4caf50",
+      "highlight": "#66bb6a"
+    },
+    "chaos_mode": {
+      "background": "linear-gradient(#1f1f1f, #420420)",
+      "text": "#ffdd57",
+      "accent": "#e53935",
+      "highlight": "#ba68c8"
+    }
+  },
+  "fonts": {
+    "primary": "Share Tech Mono, monospace",
+    "secondary": "VT323, monospace",
+    "titles": "Creepster, fantasy"
+  },
+  "frame_structure": {
+    "default": "terminal_overlay",
+    "modules": ["chat_panel", "scroll_feed", "badge_rack", "mood_matrix", "archetype_switch"],
+    "navigation_behavior": "command_line_theme",
+    "reconfigurable": true
+  },
+  "lucidus_integration": {
+    "control_scope": "entire DOM structure",
+    "input_methods": ["text", "voice", "click", "mood detection", "rank triggers"],
+    "reactions": {
+      "voice_command": {
+        "example": "Lucidus, cloak this page in shadow",
+        "effect": "toggle dark_mode"
+      },
+      "mood_shift": {
+        "example": "user_mood == 'anxious'",
+        "effect": "activate soothing UI theme"
+      },
+      "rank_event": {
+        "example": "user_rank == 'Ascended Bastard'",
+        "effect": "unlock hidden animation + soundscape"
+      }
+    }
+  },
+  "interactive_elements": {
+    "terminal_input_bar": true,
+    "floating_lucidus_avatar": true,
+    "lucidus_reactions": {
+      "hover": "mutter sarcastic prophecy",
+      "click": "open command overlay",
+      "long_press": "trigger chaos mode prompt"
+    }
+  },
+  "layout_zones": {
+    "top": "Lucidus header frame",
+    "left": "Command nav panel",
+    "center": "Interactive scrollfeed",
+    "right": "Memory or Mood feedback",
+    "bottom": "Input command bar + terminal log"
+  },
+  "easter_eggs": {
+    "konami_code": {
+      "sequence": "up up down down left right left right b a",
+      "result": "Lucidus launches hidden brotherhood prophecy"
+    },
+    "midnight_event": {
+      "time_trigger": "00:00",
+      "result": "site dims and whispers secrets"
+    }
+  },
+  "live_updates": {
+    "enable_theme_morphing": true,
+    "enable_layout_transitions": true,
+    "allow_lucidus_api_override": true
+  },
+  "user_memory_hooks": {
+    "store_last_theme": true,
+    "store_user_inputs": true,
+    "store_user_archetype": true,
+    "store_last_mood": true
+  }
+}

--- a/wp-content/dbs-library/lucidus-reactor.js
+++ b/wp-content/dbs-library/lucidus-reactor.js
@@ -1,0 +1,45 @@
+(function(){
+  'use strict';
+
+  // Loads the style codex
+  async function loadCodex(){
+    const response = await fetch('/wp-content/dbs-library/codex/lucidus-terminal-style-codex.json');
+    return response.json();
+  }
+
+  // Apply a theme mode by name
+  function applyTheme(codex, mode){
+    const palette = codex.primary_palette[mode];
+    if(!palette) return;
+    document.documentElement.style.setProperty('--lucidus-bg', palette.background);
+    document.documentElement.style.setProperty('--lucidus-text', palette.text);
+    document.documentElement.style.setProperty('--lucidus-accent', palette.accent);
+    document.documentElement.style.setProperty('--lucidus-highlight', palette.highlight);
+  }
+
+  // Interpret commands
+  function handleCommand(cmd, codex){
+    cmd = cmd.toLowerCase();
+    if(cmd.includes('dark')){
+      applyTheme(codex, 'dark_mode');
+    } else if(cmd.includes('chaos')){
+      applyTheme(codex, 'chaos_mode');
+    } else if(cmd.includes('light')){
+      applyTheme(codex, 'light_mode');
+    }
+  }
+
+  // Bind input field or voice command
+  function init(){
+    loadCodex().then(codex => {
+      const input = document.querySelector('#lucidus-command');
+      if(!input) return;
+      input.addEventListener('change', function(){
+        handleCommand(this.value, codex);
+        this.value = '';
+      });
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+})();


### PR DESCRIPTION
## Summary
- document GPT autobuilder directive in README
- add `lucidus-gpt-autobuilder-directive.json` to codex

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6848bd53f23883279164bf8a80b7d280